### PR TITLE
Use image directive for Kerberos in docker-compose and make Datadog Dockerfile more generic

### DIFF
--- a/datadog-iot/Dockerfile.template
+++ b/datadog-iot/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:latest
+FROM balenalib/%%BALENA_ARCH%%-ubuntu
 WORKDIR /usr/app
 RUN apt update && apt install -y nano wget curl sudo apt-transport-https sudo gnupg2
 RUN sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
@@ -11,4 +11,4 @@ RUN cp /usr/app/files/disk.yaml /etc/datadog-agent/conf.d/disk.d/conf.yaml.defau
 RUN cp /usr/app/files/network.yaml /etc/datadog-agent/conf.d/network.d/conf.yaml.default
 
 RUN chmod +x files/start.sh
-CMD ./files/start.sh
+CMD ["bash","./files/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ volumes:
   web: {}
 services:
   kerberos:
-    build:
-      context: kerberos
+    image: kerberos/kerberos
+    command: ["bash", "/run.sh"]
     privileged: true
     tty: true
     restart: always

--- a/kerberos/Dockerfile.aarch64
+++ b/kerberos/Dockerfile.aarch64
@@ -1,3 +1,0 @@
-FROM kerberos/kerberos@sha256:50946dc51e9ee2abc9538d232dba5dcced29a21740eaaf94622c3c167e8ffbe7
-
-CMD ["bash", "/run.sh"]

--- a/kerberos/Dockerfile.amd64
+++ b/kerberos/Dockerfile.amd64
@@ -1,3 +1,0 @@
-FROM kerberos/kerberos@sha256:5026336db4fea995ee844d4002a738fc1d64c24e7c2b94bf5ebea5ac6b380d66
-
-CMD ["bash", "/run.sh"]

--- a/kerberos/Dockerfile.armv7hf
+++ b/kerberos/Dockerfile.armv7hf
@@ -1,3 +1,0 @@
-FROM kerberos/kerberos@sha256:b8680b9bbb111c9c444ebe48500364fe0bd2dd239de71fab5647301a8679b39d
-
-CMD ["bash", "/run.sh"]


### PR DESCRIPTION

Change-type: patch
Signed-off-by: Rahul Thakoor <rahul@balena.io>