### PR TITLE
Fix datadog-iot failure looping on hostname

### DIFF
--- a/datadog-iot/files/start.sh
+++ b/datadog-iot/files/start.sh
@@ -9,4 +9,4 @@ ln -sf /var/run/balena.sock /var/run/docker.sock
 
 echo "api_key: $DD_API_KEY" | cat - files/datadog.yaml > temp && mv temp files/datadog.yaml
 
-datadog-agent -c files/datadog.yaml run
+DD_HOSTNAME=`hostname` datadog-agent -c files/datadog.yaml run


### PR DESCRIPTION
The datadog-iot service was exiting because a hostname was not defined. This PR defines `DD_HOSTNAME` for the container to provide the hostname. See Datadog [docs](https://docs.datadoghq.com/agent/troubleshooting/hostname_containers/?tab=dockeronvm#hostname-errors-in-ci-environments-sidecar-setups-and-environments-without-access-to-container-runtime) for details.